### PR TITLE
Test logging preview

### DIFF
--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -126,10 +126,17 @@ sub test_runner($){
 sub execute_test($){
   my ($test_config) = @_;
   my @output;
+  my $log_filename = "$test_config->{'executable'}" . ".log";
+  my $log_fh;
 
-  @output = `($RUN_CMD -np $test_config->{'npes'} ./$test_config->{'executable'} ) 2>/dev/null`;
+  @output = `($RUN_CMD -np $test_config->{'npes'} ./$test_config->{'executable'} ) 2>&1`;
 
-  if($output[0] =~ /Passed/){
+  open $log_fh, '>', $log_filename or die "Error opening log file '$log_filename'";
+  print $log_fh "@output";
+  close $log_fh;
+
+  # The last line of output from the test must contain "Passed"
+  if($output[$#output] =~ /Passed/){
     return $TEST_OK;
   }
 
@@ -209,6 +216,18 @@ sub run_test($$) {
 			}elsif($test_result ne $TEST_UNDEF){
   	  			print "Failed\n";
 				$ht_stats->{'fail'}++;
+
+                                my $log_filename = "$test_config->{'executable'}" . ".log";
+                                my $log_fh;
+
+                                open $log_fh, '<', $log_filename or die "Error opening log file '$log_filename'";
+                                print "===========================================================================\n";
+                                print "= TEST FAILED: $test_config->{'executable'}\n";
+                                print "===========================================================================\n";
+                                while (<$log_fh>) { print "= $_"; }
+                                print "===========================================================================\n";
+                                close $log_fh;
+
 				last;
 			}
 		}

--- a/feature_tests/Fortran/accessibility/test_shmem_acc_01.f90
+++ b/feature_tests/Fortran/accessibility/test_shmem_acc_01.f90
@@ -69,6 +69,8 @@ program test_shmem_accessible
     end if
   end if
 
+  call shmem_finalize()
+
 end program test_shmem_accessible
 
 

--- a/feature_tests/Fortran/accessibility/test_shmem_acc_02.f90
+++ b/feature_tests/Fortran/accessibility/test_shmem_acc_02.f90
@@ -70,6 +70,8 @@ program test_shmem_accessible
     end if
   end if
 
+  call shmem_finalize()
+
 end program test_shmem_accessible
 
 

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_char.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_char.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_double.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_double.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_int4.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_int4.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_int8.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_int8.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_logical.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_logical.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_real4.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_real4.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program

--- a/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_real8.f90
+++ b/feature_tests/Fortran/alloc/test_shmem_shpalloc_02_real8.f90
@@ -76,8 +76,6 @@ program test_shmem_shpalloc
   ! All PEs wait until PE 0 has finished.
   call shmem_barrier_all()
 
-  call shpdeallc(ptr, errcode, abort)
-
   call shmem_finalize()
 
 end program


### PR DESCRIPTION
Posting 52093ef for feedback (it is based on PR #7, which separately proposes the bugfixes in 8d36af3 and ab90dfd)  ---

This patch is a first cut at capturing log files and printing out any error messages when tests fail.  This is extremely helpful for us with diagnosing failures that occur within the Travis CI testing environment.  Interested to hear your thoughts.  Some particular things to consider:
- Log files are named: test-name.x.log
- The last line of output from the test must contain "Passed" for testrunner to catch success.
- On error, the log file is always dumped.  We may want an option to enable/disable this.
