### PR TITLE
bug fix in test_shmem_finalize.c

### DIFF
--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -71,6 +71,7 @@ main (int argc, char **argv)
 
     if (npes > 1) {
 
+        shmem_barrier_all();
         src = (uint64_t)((me+1)%npes);
         nextpe = (me+1)%npes;
         shmem_put64 (&dest, &src, 1, nextpe);


### PR DESCRIPTION
It's only a coincidence that the code passes (it "failed" in another implementation).  The last PE (npes-1) could be faster than PE 0.  If PE (npes-1) puts it's source value before PE 0 sets dest = -9, PE 0 ends up overwriting the value put there. I added a barrier_all() to synchronize the PEs to prevent this from happening.  Alternatively, dest = -9 could be specified at compile time above main().
