### PR TITLE
bug fix in test_shmem_finalize.c take 2

### DIFF
--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -55,7 +55,7 @@
 #include <shmem.h>
 #include <stdint.h>
 
-uint64_t dest;
+uint64_t dest = -9;
 
 int
 main (int argc, char **argv)
@@ -67,7 +67,6 @@ main (int argc, char **argv)
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
-    dest = -9;
 
     if (npes > 1) {
 


### PR DESCRIPTION
@shamisp suggested the dest value be initialized before shmem_init() to use implicit synchronization rather than inserting explicit synchronization with a barrier
https://github.com/openshmem-org/tests-uh/pull/10
