### PR TITLE
Update c tests

### DIFF
--- a/feature_tests/C/Makefile.opts
+++ b/feature_tests/C/Makefile.opts
@@ -39,29 +39,13 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-include Makefile.opts
+SHELL = /bin/sh
 
+SHMEM_CFLAGS=-g -O0
 
-C_TESTS        = $(wildcard *.c)
+GCC=gcc
 
-C_EXES         = $(C_TESTS:.c=.x)
+CC = oshcc
 
-EXES           = $(C_EXES)
-
-.PHONY: clean all default
-
-all default:    $(EXES)
-
-.SUFFIXES: .x
-
-%.x:    %.c
-	$(CC) $(SHMEM_CFLAGS) -o $@ $^ -lm
-
-run:	$(EXES)
-	 @../${TEST_RUNNER}
-
-
-clean:
-	 rm -f $(EXES)
-
+TEST_RUNNER = ../common/testrunner.pl
 

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -14,6 +14,6 @@ test_shmem_put_globals.x, 2, All PEs put an array to right neighbor (global vari
 test_shmem_put_shmem_malloc.x, 2, All PEs put an array to right neighbor (allocated using shmem_malloc),,0,Pass
 test_shmem_query.x, 2, Test for info/query interfaces,,0,Pass
 test_shmem_reduction.x, 2, Test for SHMEM reduction calls,,0,Pass
-test_shmem_synchronization.x, 2, Tests SHMEM conditional wait calls,,1,Pass
+test_shmem_synchronization.x, 2, Tests SHMEM conditional wait calls,,0,Pass
 test_shmem_zero_get.x, 2, All PEs get an array of size 0 from right neighbor,,0,Pass
 test_shmem_zero_put.x, 2, All PEs put an array of size 0 to right neighbor,,0,Pass

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -1,7 +1,7 @@
 test_shmem_accessible.x, 2, Test if all PEs are accessible,,0,Pass
 test_shmem_atomics.x, 2, Test all atomics,,0,Pass
 test_shmem_barrier.x, 2, Tests shmem_barrier call,,0,Pass
-test_shmem_broadcast.x, 4, PE 0 broadcasts to all other PEs,,0,Pass
+test_shmem_broadcast.x, 2, PE 0 broadcasts to all other PEs,,0,Pass
 test_shmem_collects.x, 2, Each PE contributes 4 elements to shmem_fcollect32 call,,0,Pass
 test_shmem_finalize.x, 2, All PEs put a 64-bit value to its right neighbor and expect the transfer to complete after shmem_finalize,,0,Pass
 test_shmem_get.x, 2, All PEs get an array from right neighbor,,0,Pass
@@ -14,6 +14,6 @@ test_shmem_put_globals.x, 2, All PEs put an array to right neighbor (global vari
 test_shmem_put_shmem_malloc.x, 2, All PEs put an array to right neighbor (allocated using shmem_malloc),,0,Pass
 test_shmem_query.x, 2, Test for info/query interfaces,,0,Pass
 test_shmem_reduction.x, 2, Test for SHMEM reduction calls,,0,Pass
-test_shmem_synchronization.x, 2, Tests SHMEM conditional wait calls,,0,Pass
+test_shmem_synchronization.x, 2, Tests SHMEM conditional wait calls,,1,Pass
 test_shmem_zero_get.x, 2, All PEs get an array of size 0 from right neighbor,,0,Pass
 test_shmem_zero_put.x, 2, All PEs put an array of size 0 to right neighbor,,0,Pass

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -3,7 +3,7 @@ test_shmem_atomics.x, 2, Test all atomics,,0,Pass
 test_shmem_barrier.x, 2, Tests shmem_barrier call,,0,Pass
 test_shmem_broadcast.x, 2, PE 0 broadcasts to all other PEs,,0,Pass
 test_shmem_collects.x, 2, Each PE contributes 4 elements to shmem_fcollect32 call,,0,Pass
-test_shmem_finalize.x, 2, All PEs put a 64-bit value to its right neighbor and expect the transfer to complete after shmem_finalize,,0,Pass
+test_shmem_finalize.x, 2, Test shmem_finalize barrier semantic,,0,Pass
 test_shmem_get.x, 2, All PEs get an array from right neighbor,,0,Pass
 test_shmem_get_globals.x, 2, All PEs get an array from right neighbor (global variables),,0,Pass
 test_shmem_get_shmem_malloc.x, 2, All PEs get an array from right neighbor (allocated using shmem_malloc),,0,Pass

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -1,0 +1,19 @@
+test_shmem_accessible.x, 2, Test if all PEs are accessible,,0,Pass
+test_shmem_atomics.x, 2, Test all atomics,,0,Pass
+test_shmem_barrier.x, 2, Tests shmem_barrier call,,0,Pass
+test_shmem_broadcast.x, 4, PE 0 broadcasts to all other PEs,,0,Pass
+test_shmem_collects.x, 2, Each PE contributes 4 elements to shmem_fcollect32 call,,0,Pass
+test_shmem_finalize.x, 4, All PEs put a 64-bit value to its right neighbor and expect the transfer to complete after shmem_finalize,,0,Pass
+test_shmem_get.x, 2, All PEs get an array from right neighbor,,0,Pass
+test_shmem_get_globals.x, 2, All PEs get an array from right neighbor (global variables),,0,Pass
+test_shmem_get_shmem_malloc.x, 2, All PEs get an array from right neighbor (allocated using shmem_malloc),,0,Pass
+test_shmem_global_exit.x, 2, All PEs sleep for a finite number of seconds while PE0 call shmem_global_exit,,0,Pass
+test_shmem_lock.x, 2, Tests shmem_set_lock shmem_test_lock and shmem_clear_lock calls,,0,Pass
+test_shmem_put.x, 2, All PEs put an array to right neighbor,,0,Pass
+test_shmem_put_globals.x, 2, All PEs put an array to right neighbor (global variables),,0,Pass
+test_shmem_put_shmem_malloc.x, 2, All PEs put an array to right neighbor (allocated using shmem_malloc),,0,Pass
+test_shmem_query.x, 2, Test for info/query interfaces,,0,Pass
+test_shmem_reduction.x, 2, Test for SHMEM reduction calls,,0,Pass
+test_shmem_synchronization.x, 2, Tests SHMEM conditional wait calls,,0,Pass
+test_shmem_zero_get.x, 2, All PEs get an array of size 0 from right neighbor,,0,Pass
+test_shmem_zero_put.x, 2, All PEs put an array of size 0 to right neighbor,,0,Pass

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -7,7 +7,7 @@ test_shmem_finalize.x, 2, All PEs put a 64-bit value to its right neighbor and e
 test_shmem_get.x, 2, All PEs get an array from right neighbor,,0,Pass
 test_shmem_get_globals.x, 2, All PEs get an array from right neighbor (global variables),,0,Pass
 test_shmem_get_shmem_malloc.x, 2, All PEs get an array from right neighbor (allocated using shmem_malloc),,0,Pass
-test_shmem_global_exit.x, 2, All PEs sleep for a finite number of seconds while PE0 call shmem_global_exit,,0,Pass
+test_shmem_global_exit.x, 2, All PEs sleep for a finite number of seconds while PE0 call shmem_global_exit,,0,ExitCode99
 test_shmem_lock.x, 2, Tests shmem_set_lock shmem_test_lock and shmem_clear_lock calls,,0,Pass
 test_shmem_put.x, 2, All PEs put an array to right neighbor,,0,Pass
 test_shmem_put_globals.x, 2, All PEs put an array to right neighbor (global variables),,0,Pass

--- a/feature_tests/C/test_parameters.conf
+++ b/feature_tests/C/test_parameters.conf
@@ -3,7 +3,7 @@ test_shmem_atomics.x, 2, Test all atomics,,0,Pass
 test_shmem_barrier.x, 2, Tests shmem_barrier call,,0,Pass
 test_shmem_broadcast.x, 4, PE 0 broadcasts to all other PEs,,0,Pass
 test_shmem_collects.x, 2, Each PE contributes 4 elements to shmem_fcollect32 call,,0,Pass
-test_shmem_finalize.x, 4, All PEs put a 64-bit value to its right neighbor and expect the transfer to complete after shmem_finalize,,0,Pass
+test_shmem_finalize.x, 2, All PEs put a 64-bit value to its right neighbor and expect the transfer to complete after shmem_finalize,,0,Pass
 test_shmem_get.x, 2, All PEs get an array from right neighbor,,0,Pass
 test_shmem_get_globals.x, 2, All PEs get an array from right neighbor (global variables),,0,Pass
 test_shmem_get_shmem_malloc.x, 2, All PEs get an array from right neighbor (allocated using shmem_malloc),,0,Pass

--- a/feature_tests/C/test_shmem_accessible.c
+++ b/feature_tests/C/test_shmem_accessible.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_accessible.c
+++ b/feature_tests/C/test_shmem_accessible.c
@@ -65,6 +65,7 @@ main (int argc, char *argv[])
     int *shm_dest;
     int me, npes, i;
     int pe_acc_success = 0;
+    int fail_count = 0;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -78,26 +79,28 @@ main (int argc, char *argv[])
 
         if (!check_it (&global_dest)) {   /* long global: yes */
             printf ("Test Global Address Accessible: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Test Global Address Accessible: Passed\n");
         }
         if (!check_it (&static_dest)) {   /* static int global: yes */
             printf ("Test Static Global Address Accessible: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Test Static Global Address Accessible: Passed\n");
         }
         if (check_it (&local_dest)) { /* main() stack: no */
             printf ("Test Stack Address Accessible: Failed\n");
-
+            fail_count++;
         }
         else {
             printf ("Test Stack Address Accessible: Passed\n");
         }
         if (!check_it (shm_dest)) {   /* shmem_malloc: yes */
-
             printf ("Test Shmalloc-ed Address Accessible: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Test Shmalloc-ed Address Accessible: Passed\n");
@@ -113,12 +116,16 @@ main (int argc, char *argv[])
         }
         if (pe_acc_success == 1) {
             printf ("Test shmem_pe_accessible: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Test shmem_pe_accessible: Passed\n");
         }
 
-
+        if (fail_count == 0)
+            printf("All Tests Passed\n");
+        else
+            printf("%d Tests Failed\n", fail_count);
     }
 
     shmem_free (shm_dest);

--- a/feature_tests/C/test_shmem_atomics.c
+++ b/feature_tests/C/test_shmem_atomics.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_atomics.c
+++ b/feature_tests/C/test_shmem_atomics.c
@@ -168,7 +168,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_swap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success2_p1 && success2_p2) {
@@ -176,7 +176,7 @@ main ()
             }
             else {
                 printf ("Test shmem_float_swap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -184,7 +184,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_swap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success4_p1 && success4_p2) {
@@ -192,7 +192,7 @@ main ()
             }
             else {
                 printf ("Test shmem_double_swap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -200,7 +200,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_swap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
         }
@@ -263,7 +263,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_cswap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -271,7 +271,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_cswap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -279,7 +279,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_cswap: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
         }
@@ -339,7 +339,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_fadd: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -347,7 +347,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_fadd: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -355,7 +355,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_fadd: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
         }
@@ -415,7 +415,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_finc: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -423,7 +423,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_finc: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -431,7 +431,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_finc: Failed\n");
-                *fail_count++;
+                (*fail_count)++;
             }
         }
 

--- a/feature_tests/C/test_shmem_atomics.c
+++ b/feature_tests/C/test_shmem_atomics.c
@@ -83,6 +83,9 @@ main ()
     int success4_p1;
     int success5_p1;
 
+    int *fail_count;
+    int fail_count_remote;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -98,6 +101,9 @@ main ()
         dest3 = (long *) shmem_malloc (sizeof (*dest3));
         dest4 = (double *) shmem_malloc (sizeof (*dest4));
         dest5 = (long long *) shmem_malloc (sizeof (*dest5));
+
+        fail_count = (int *) shmem_malloc (sizeof (int));
+        *fail_count = 0;
 
         *dest1 = *dest2 = *dest3 = *dest4 = *dest5 = me;
         new_val1 = new_val2 = new_val3 = new_val4 = new_val5 = me;
@@ -161,6 +167,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_swap: Failed\n");
+                *fail_count++;
             }
 
             if (success2_p1 && success2_p2) {
@@ -168,6 +175,7 @@ main ()
             }
             else {
                 printf ("Test shmem_float_swap: Failed\n");
+                *fail_count++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -175,6 +183,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_swap: Failed\n");
+                *fail_count++;
             }
 
             if (success4_p1 && success4_p2) {
@@ -182,6 +191,7 @@ main ()
             }
             else {
                 printf ("Test shmem_double_swap: Failed\n");
+                *fail_count++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -189,6 +199,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_swap: Failed\n");
+                *fail_count++;
             }
 
         }
@@ -251,6 +262,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_cswap: Failed\n");
+                *fail_count++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -258,6 +270,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_cswap: Failed\n");
+                *fail_count++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -265,6 +278,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_cswap: Failed\n");
+                *fail_count++;
             }
 
         }
@@ -324,6 +338,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_fadd: Failed\n");
+                *fail_count++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -331,6 +346,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_fadd: Failed\n");
+                *fail_count++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -338,6 +354,7 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_fadd: Failed\n");
+                *fail_count++;
             }
 
         }
@@ -397,6 +414,7 @@ main ()
             }
             else {
                 printf ("Test shmem_int_finc: Failed\n");
+                *fail_count++;
             }
 
             if (success3_p1 && success3_p2) {
@@ -404,6 +422,7 @@ main ()
             }
             else {
                 printf ("Test shmem_long_finc: Failed\n");
+                *fail_count++;
             }
 
             if (success5_p1 && success5_p2) {
@@ -411,16 +430,31 @@ main ()
             }
             else {
                 printf ("Test shmem_longlong_finc: Failed\n");
+                *fail_count++;
             }
-
         }
+
         shmem_barrier_all ();
+
+        if (me == 0) {
+            fail_count_remote = shmem_int_g(fail_count, npes - 1);
+
+            *fail_count += fail_count_remote;
+
+            if (*fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", *fail_count);
+        }
+
+        shmem_barrier_all();
 
         shmem_free (dest1);
         shmem_free (dest2);
         shmem_free (dest3);
         shmem_free (dest4);
         shmem_free (dest5);
+        shmem_free (fail_count);
 
     }
     else {

--- a/feature_tests/C/test_shmem_barrier.c
+++ b/feature_tests/C/test_shmem_barrier.c
@@ -7,7 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
- * Copyright (c) 2015 Intel Corporation
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_barrier.c
+++ b/feature_tests/C/test_shmem_barrier.c
@@ -60,6 +60,8 @@ main ()
     int me, npes;
     int i;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -74,11 +76,13 @@ main ()
 
         shmem_barrier_all ();
 
-        if (me == npes - 1) {
+        if (me == 0) {
             if (x == 4)
                 printf ("Test shmem_barrier_all: Passed\n");
-            else
+            else {
                 printf ("Test shmem_barrier_all: Failed\n");
+                fail_count++;
+            }
         }
 
         x = -9;
@@ -86,17 +90,27 @@ main ()
 
         if (me == 0 || me == 1) {
 
-            if (me == 0)
-                shmem_int_p (&x, 4, 1);
+            if (me == 1)
+                shmem_int_p (&x, 4, 0);
 
             shmem_barrier (0, 0, 2, pSync);
 
-            if (me == 1) {
+            if (me == 0) {
                 if (x == 4)
                     printf ("Test shmem_barrier: Passed\n");
-                else
+                else {
                     printf ("Test shmem_barrier: Failed\n");
+                    fail_count++;
+                }
             }
+        }
+
+        if (me == 0)
+        {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
         }
     }
     else {

--- a/feature_tests/C/test_shmem_broadcast.c
+++ b/feature_tests/C/test_shmem_broadcast.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_broadcast.c
+++ b/feature_tests/C/test_shmem_broadcast.c
@@ -70,6 +70,8 @@ main (void)
     long *source;
     int i, me, npes;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -116,13 +118,14 @@ main (void)
         }
 
         shmem_barrier_all ();
-        if (me == npes - 1) {
-            shmem_int_get (&success32_root, &success32, 1, 0);
+        if (me == 0) {
+            shmem_int_get (&success32_root, &success32, 1, npes - 1);
             if (success32 == 0 && success32_root == 0) {
                 printf ("Test shmem_broadcast32: Passed\n");
             }
             else {
                 printf ("Test shmem_broadcast32: Failed\n");
+                fail_count++;
             }
         }
 
@@ -151,13 +154,14 @@ main (void)
 
         shmem_barrier_all ();
 
-        if (me == npes - 1) {
-            shmem_int_get (&success64_root, &success64, 1, 0);
+        if (me == 0) {
+            shmem_int_get (&success64_root, &success64, 1, npes - 1 );
             if (success64 == 0 && success64_root == 0) {
                 printf ("Test shmem_broadcast64: Passed\n");
             }
             else {
                 printf ("Test shmem_broadcast64: Failed\n");
+                fail_count++;
             }
         }
 
@@ -209,13 +213,14 @@ main (void)
         }
 
         shmem_barrier_all ();
-        if (me == 2) {
-            shmem_int_get (&success32_root, &success32, 1, 0);
+        if (me == 0) {
+            shmem_int_get (&success32_root, &success32, 1, 2);
             if (success32 == 0 && success32_root == 0) {
                 printf ("Test strided shmem_broadcast32: Passed\n");
             }
             else {
                 printf ("Test strided shmem_broadcast32: Failed\n");
+                fail_count++;
             }
         }
 
@@ -252,14 +257,22 @@ main (void)
 
         shmem_barrier_all ();
 
-        if (me == 2) {
-            shmem_int_get (&success64_root, &success64, 1, 0);
+        if (me == 0) {
+            shmem_int_get (&success64_root, &success64, 1, 2);
             if (success64 == 0 && success64_root == 0) {
                 printf ("Test strided shmem_broadcast64: Passed\n");
             }
             else {
                 printf ("Test strided shmem_broadcast64: Failed\n");
+                fail_count++;
             }
+        }
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
         }
 
         shmem_free (targ);

--- a/feature_tests/C/test_shmem_broadcast.c
+++ b/feature_tests/C/test_shmem_broadcast.c
@@ -268,13 +268,6 @@ main (void)
             }
         }
 
-        if (me == 0) {
-            if (fail_count == 0)
-                printf("All Tests Passed\n");
-            else
-                printf("%d Tests Failed\n", fail_count);
-        }
-
         shmem_free (targ);
         shmem_free (src);
         shmem_free (dest);
@@ -285,6 +278,13 @@ main (void)
         if (me == 0) {
             printf ("Number of PEs must be > 2 to test strided broadcast, test skipped\n");
         }
+    }
+
+    if (me == 0) {
+      if (fail_count == 0)
+        printf("All Tests Passed\n");
+      else
+        printf("%d Tests Failed\n", fail_count);
     }
 
     shmem_finalize ();

--- a/feature_tests/C/test_shmem_collects.c
+++ b/feature_tests/C/test_shmem_collects.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_collects.c
+++ b/feature_tests/C/test_shmem_collects.c
@@ -76,6 +76,8 @@ main (void)
     int *compare_dst1, *compare_dst3;
     long *compare_dst2, *compare_dst4;
 
+    int fail_count = 0;
+
     shmem_init ();
     npes = shmem_n_pes ();
     me = shmem_my_pe ();
@@ -125,6 +127,7 @@ main (void)
             }
             if (success == 1) {
                 printf ("Test shmem_fcollect32: Failed\n");
+                fail_count++;
             }
             else {
                 printf ("Test shmem_fcollect32: Passed\n");
@@ -162,6 +165,7 @@ main (void)
             }
             if (success == 1) {
                 printf ("Test shmem_fcollect64: Failed\n");
+                fail_count++;
             }
             else {
                 printf ("Test shmem_fcollect64: Passed\n");
@@ -222,6 +226,7 @@ main (void)
             }
             if (success == 1) {
                 printf ("Test shmem_collect32: Failed\n");
+                fail_count++;
             }
             else {
                 printf ("Test shmem_collect32: Passed\n");
@@ -271,10 +276,18 @@ main (void)
             }
             if (success == 1) {
                 printf ("Test shmem_collect64: Failed\n");
+                fail_count++;
             }
             else {
                 printf ("Test shmem_collect64: Passed\n");
             }
+        }
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
         }
 
         free (compare_dst4);

--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -98,9 +98,9 @@ main (int argc, char **argv)
     }
     else {
         printf ("Number of PEs must be > 1 to test shmem finalize, test skipped\n");
-    }
 
-    shmem_finalize ();
+        shmem_finalize ();
+    }
 
     return 0;
 }

--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -55,7 +55,7 @@
 #include <shmem.h>
 #include <stdint.h>
 
-uint64_t dest;
+uint64_t dest = -9;
 
 int
 main (int argc, char **argv)
@@ -69,7 +69,6 @@ main (int argc, char **argv)
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
-    dest = -9;
 
     if (npes > 1) {
 

--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_finalize.c
+++ b/feature_tests/C/test_shmem_finalize.c
@@ -64,6 +64,8 @@ main (int argc, char **argv)
     int me, npes;
     uint64_t src;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -81,13 +83,21 @@ main (int argc, char **argv)
           /* Check for completion of all communication */
           if ((int)dest == me)
               printf ("Test shmem_finalize: Passed\n");
-          else
+          else {
               printf ("Test shmem_finalize: Failed\n");
+              fail_count++;
+          }
+        }
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
         }
     }
     else {
         printf ("Number of PEs must be > 1 to test shmem finalize, test skipped\n");
-
     }
 
     shmem_finalize ();

--- a/feature_tests/C/test_shmem_get.c
+++ b/feature_tests/C/test_shmem_get.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_get.c
+++ b/feature_tests/C/test_shmem_get.c
@@ -96,6 +96,7 @@ main (int argc, char **argv)
     double *src12;
     float *src13;
 
+    int fail_count = 0;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -210,36 +211,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_get: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_get: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_get: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_get: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_get: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_get: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_get: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_getmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_getmem: Failed\n");
+                fail_count++;
+            }
 
         }
         shmem_barrier_all ();
@@ -277,18 +294,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -324,17 +347,22 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
                 if (success2 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
-
+                    fail_count++;
+                }
                 if (success3 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -353,30 +381,44 @@ main (int argc, char **argv)
         if (me == 0) {
             if (dest9 == 1)
                 printf ("Test shmem_short_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_g: Failed\n");
+                fail_count++;
+            }
             if (dest10 == 1)
                 printf ("Test shmem_int_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_g: Failed\n");
+                fail_count++;
+            }
             if (dest11 == 1)
                 printf ("Test shmem_long_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_g: Failed\n");
+                fail_count++;
+            }
             if (dest12 == 1)
                 printf ("Test shmem_double_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_g: Failed\n");
+                fail_count++;
+            }
             if (dest13 == 1)
                 printf ("Test shmem_float_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_g: Failed\n");
-
-
+                fail_count++;
+            }
         }
 
         shmem_barrier_all ();
 
+        if (me == 0) {
+          if (fail_count == 0)
+              printf("All Tests Passed\n");
+          else
+              printf("%d Tests Failed\n", fail_count);
+        }
 
         shmem_free (src1);
         shmem_free (src2);

--- a/feature_tests/C/test_shmem_get_globals.c
+++ b/feature_tests/C/test_shmem_get_globals.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_get_globals.c
+++ b/feature_tests/C/test_shmem_get_globals.c
@@ -95,7 +95,7 @@ main (int argc, char **argv)
     double dest12;
     float dest13;
 
-
+    int fail_count = 0;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -195,37 +195,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_get: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_get: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_get: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_get: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_get: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_get: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_get: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_getmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_getmem: Failed\n");
-
+                fail_count++;
+            }
         }
         shmem_barrier_all ();
 
@@ -262,18 +277,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -309,17 +330,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         /* Testing shmem_iget32, shmem_iget64, shmem_iget128 */
@@ -356,18 +384,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_iget32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iget64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_iget128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -403,17 +437,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_iget32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_iget64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iget128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -463,25 +504,34 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_iget: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_iget: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_iget: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_iget: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_iget: Failed\n");
-
+                fail_count++;
+            }
         }
 
         /* Testing shmem_double_g, shmem_float_g, shmem_int_g, shmem_long_g,
@@ -499,29 +549,44 @@ main (int argc, char **argv)
         if (me == 0) {
             if (dest9 == 1)
                 printf ("Test shmem_short_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_g: Failed\n");
+                fail_count++;
+            }
             if (dest10 == 1)
                 printf ("Test shmem_int_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_g: Failed\n");
+                fail_count++;
+            }
             if (dest11 == 1)
                 printf ("Test shmem_long_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_g: Failed\n");
+                fail_count++;
+            }
             if (dest12 == 1)
                 printf ("Test shmem_double_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_g: Failed\n");
+                fail_count++;
+            }
             if (dest13 == 1)
                 printf ("Test shmem_float_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_g: Failed\n");
-
-
+                fail_count++;
+            }
         }
 
         shmem_barrier_all ();
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
     }
     else {
         printf ("Number of PEs must be > 1 to test shmem get, test skipped\n");

--- a/feature_tests/C/test_shmem_get_shmem_malloc.c
+++ b/feature_tests/C/test_shmem_get_shmem_malloc.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_get_shmem_malloc.c
+++ b/feature_tests/C/test_shmem_get_shmem_malloc.c
@@ -97,6 +97,7 @@ main (int argc, char **argv)
     double *src12;
     float *src13;
 
+    int fail_count = 0;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -211,37 +212,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_get: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_get: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_get: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_get: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_get: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_get: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_get: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_get: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_getmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_getmem: Failed\n");
-
+                fail_count++;
+            }
         }
         shmem_barrier_all ();
 
@@ -278,18 +294,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -325,17 +347,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_get32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_get64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -373,18 +402,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_iget32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iget64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_iget128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -420,17 +455,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_iget32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_iget64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iget128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iget128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -480,25 +522,34 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_iget: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_iget: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_iget: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_iget: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_iget: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_iget: Failed\n");
-
+                fail_count++;
+            }
         }
 
 
@@ -518,30 +569,44 @@ main (int argc, char **argv)
         if (me == 0) {
             if (dest9 == 1)
                 printf ("Test shmem_short_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_g: Failed\n");
+                fail_count++;
+            }
             if (dest10 == 1)
                 printf ("Test shmem_int_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_g: Failed\n");
+                fail_count++;
+            }
             if (dest11 == 1)
                 printf ("Test shmem_long_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_g: Failed\n");
+                fail_count++;
+            }
             if (dest12 == 1)
                 printf ("Test shmem_double_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_g: Failed\n");
+                fail_count++;
+            }
             if (dest13 == 1)
                 printf ("Test shmem_float_g: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_g: Failed\n");
-
-
+                fail_count++;
+            }
         }
 
         shmem_barrier_all ();
 
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
 
         shmem_free (src1);
         shmem_free (src2);

--- a/feature_tests/C/test_shmem_lock.c
+++ b/feature_tests/C/test_shmem_lock.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_lock.c
+++ b/feature_tests/C/test_shmem_lock.c
@@ -59,6 +59,8 @@ main (int argc, char **argv)
     int ret_val;
     int new_val;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -83,8 +85,10 @@ main (int argc, char **argv)
         if (me == 0) {
             if (x == npes)
                 printf ("Test for set, and clear lock: Passed\n");
-            else
+            else {
                 printf ("Test for set, and clear lock: Failed\n");
+                fail_count++;
+            }
             x = 0;
         }
         shmem_barrier_all ();
@@ -105,11 +109,21 @@ main (int argc, char **argv)
         if (me == 0) {
             if (x == npes)
                 printf ("Test for test lock: Passed\n");
-            else
+            else {
                 printf ("Test for test lock: Failed\n");
+                fail_count++;
+            }
 
         }
+
         shmem_barrier_all ();
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
     }
     else
         printf ("Number of PEs must be > 1 to test locks, test skipped\n");

--- a/feature_tests/C/test_shmem_put.c
+++ b/feature_tests/C/test_shmem_put.c
@@ -181,7 +181,7 @@ main (int argc, char **argv)
 
         if (me == 0) {
             for (i = 0; i < N; i += 1) {
-                if (dest1[i] == (npes - 1)) {
+                if (dest1[i] != (npes - 1)) {
                     success1 = 1;
                 }
                 if (dest2[i] != (npes - 1)) {

--- a/feature_tests/C/test_shmem_put.c
+++ b/feature_tests/C/test_shmem_put.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_put.c
+++ b/feature_tests/C/test_shmem_put.c
@@ -67,6 +67,7 @@ main (int argc, char **argv)
     int me, npes;
     int success1, success2, success3, success4, success5, success6, success7,
         success8;
+    int fail_count = 0;
 
     short src1[N];
     int src2[N];
@@ -180,7 +181,7 @@ main (int argc, char **argv)
 
         if (me == 0) {
             for (i = 0; i < N; i += 1) {
-                if (dest1[i] != (npes - 1)) {
+                if (dest1[i] == (npes - 1)) {
                     success1 = 1;
                 }
                 if (dest2[i] != (npes - 1)) {
@@ -208,36 +209,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_put: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_put: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_put: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_put: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_put: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_put: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_put: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_putmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_putmem: Failed\n");
+                fail_count++;
+            }
 
         }
         shmem_barrier_all ();
@@ -275,18 +292,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -322,17 +345,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -351,25 +381,39 @@ main (int argc, char **argv)
         if (me == 0) {
             if (*dest9 == (npes - 1))
                 printf ("Test shmem_short_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_p: Failed\n");
+                fail_count++;
+            }
             if (*dest10 == (npes - 1))
                 printf ("Test shmem_int_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_p: Failed\n");
+                fail_count++;
+            }
             if (*dest11 == (npes - 1))
                 printf ("Test shmem_long_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_p: Failed\n");
+                fail_count++;
+            }
             if (*dest12 == (npes - 1))
                 printf ("Test shmem_double_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_p: Failed\n");
+                fail_count++;
+            }
             if (*dest13 == (npes - 1))
                 printf ("Test shmem_float_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_p: Failed\n");
+                fail_count++;
+            }
 
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
 
         }
 

--- a/feature_tests/C/test_shmem_put.c
+++ b/feature_tests/C/test_shmem_put.c
@@ -409,12 +409,13 @@ main (int argc, char **argv)
                 printf ("Test shmem_float_p: Failed\n");
                 fail_count++;
             }
+        }
 
+        if (me == 0) {
             if (fail_count == 0)
                 printf("All Tests Passed\n");
             else
                 printf("%d Tests Failed\n", fail_count);
-
         }
 
         shmem_barrier_all ();

--- a/feature_tests/C/test_shmem_put_globals.c
+++ b/feature_tests/C/test_shmem_put_globals.c
@@ -7,6 +7,7 @@
  *  by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *  (shmem) is released by Open Source Software Solutions, Inc., under an
  *  agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_put_globals.c
+++ b/feature_tests/C/test_shmem_put_globals.c
@@ -96,7 +96,7 @@ main (int argc, char **argv)
     double src12;
     float src13;
 
-
+    int fail_count = 0;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -195,37 +195,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_put: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_put: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_put: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_put: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_put: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_put: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_put: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_putmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_putmem: Failed\n");
-
+                fail_count++;
+            }
         }
         shmem_barrier_all ();
 
@@ -262,18 +277,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -309,17 +330,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         /* Testing shmem_iput32, shmem_iput64, shmem_iput128 */
@@ -356,18 +384,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_iput32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iput64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_iput128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -403,17 +437,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_iput32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_iput64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iput128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -463,25 +504,34 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_iput: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_iput: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_iput: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_iput: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_iput: Failed\n");
-
+                fail_count++;
+            }
         }
 
         /* Testing shmem_double_p, shmem_float_p, shmem_int_p, shmem_long_p,
@@ -499,30 +549,44 @@ main (int argc, char **argv)
         if (me == 0) {
             if (dest9 == (npes - 1))
                 printf ("Test shmem_short_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_p: Failed\n");
+                fail_count++;
+            }
             if (dest10 == (npes - 1))
                 printf ("Test shmem_int_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_p: Failed\n");
+                fail_count++;
+            }
             if (dest11 == (npes - 1))
                 printf ("Test shmem_long_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_p: Failed\n");
+                fail_count++;
+            }
             if (dest12 == (npes - 1))
                 printf ("Test shmem_double_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_p: Failed\n");
+                fail_count++;
+            }
             if (dest13 == (npes - 1))
                 printf ("Test shmem_float_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_p: Failed\n");
-
-
+                fail_count++;
+            }
         }
 
         shmem_barrier_all ();
 
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
     }
     else {
         printf ("Number of PEs must be > 1 to test shmem put, test skipped\n");

--- a/feature_tests/C/test_shmem_put_shmem_malloc.c
+++ b/feature_tests/C/test_shmem_put_shmem_malloc.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_put_shmem_malloc.c
+++ b/feature_tests/C/test_shmem_put_shmem_malloc.c
@@ -69,6 +69,8 @@ main (int argc, char **argv)
     int success1, success2, success3, success4, success5, success6, success7,
         success8;
 
+    int fail_count = 0;
+
     short src1[N];
     int src2[N];
     long src3[N];
@@ -209,37 +211,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_put: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_put: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_put: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_put: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_put: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_put: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_put: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_put: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_putmem: Passed\n");
-            else
+            else {
                 printf ("Test shmem_putmem: Failed\n");
-
+                fail_count++;
+            }
         }
         shmem_barrier_all ();
 
@@ -276,18 +293,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -323,17 +346,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_put32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_put64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -371,18 +401,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_iput32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput32: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iput64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_iput128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput128: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -418,17 +454,24 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_iput32: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput32: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_iput64: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput64: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_iput128: Passed\n");
-                else
+                else {
                     printf ("Test shmem_iput128: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
@@ -478,25 +521,34 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_iput: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_iput: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_iput: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_iput: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_iput: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_iput: Failed\n");
-
+                fail_count++;
+            }
         }
 
 
@@ -515,29 +567,44 @@ main (int argc, char **argv)
         if (me == 0) {
             if (*dest9 == (npes - 1))
                 printf ("Test shmem_short_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_p: Failed\n");
+                fail_count++;
+            }
             if (*dest10 == (npes - 1))
                 printf ("Test shmem_int_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_p: Failed\n");
+                fail_count++;
+            }
             if (*dest11 == (npes - 1))
                 printf ("Test shmem_long_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_p: Failed\n");
+                fail_count++;
+            }
             if (*dest12 == (npes - 1))
                 printf ("Test shmem_double_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_p: Failed\n");
+                fail_count++;
+            }
             if (*dest13 == (npes - 1))
                 printf ("Test shmem_float_p: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_p: Failed\n");
-
-
+                fail_count++;
+            }
         }
 
         shmem_barrier_all ();
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
 
         shmem_free (dest1);
         shmem_free (dest2);

--- a/feature_tests/C/test_shmem_query.c
+++ b/feature_tests/C/test_shmem_query.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_query.c
+++ b/feature_tests/C/test_shmem_query.c
@@ -68,34 +68,44 @@ main ()
     int major_ver, minor_ver;
     int me;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
 
-    if(me == 0){
+    if (me == 0) {
 
       shmem_info_get_version (&major_ver, &minor_ver);
       shmem_info_get_name (name);
 
       if (major_ver == _SHMEM_MAJOR_VERSION) {
-          PRINT_VER("Major","Passed")
+          PRINT_VER("Major","Passed");
       }
       else {
-          PRINT_VER("Major","Failed")
+          PRINT_VER("Major","Failed");
+          fail_count++;
       }
 
       if (minor_ver == _SHMEM_MINOR_VERSION) {
-          PRINT_VER("Minor","Passed")
+          PRINT_VER("Minor","Passed");
       }
       else {
-          PRINT_VER("Minor","Failed")
+          PRINT_VER("Minor","Failed");
+          fail_count++;
       }
 
       if (strlen (name) < _SHMEM_MAX_NAME_LEN) {
-          PRINT_NAME("Passed")
+          PRINT_NAME("Passed");
       }
       else {
-          PRINT_NAME("Undefined")
+          PRINT_NAME("Undefined");
+          fail_count++;
       }
+
+      if (fail_count == 0)
+            printf("All Tests Passed\n");
+      else
+            printf("%d Tests Failed\n", fail_count);
     }
 
     shmem_finalize ();

--- a/feature_tests/C/test_shmem_reduction.c
+++ b/feature_tests/C/test_shmem_reduction.c
@@ -511,21 +511,6 @@ main ()
         dst5[i] = -9;
         dst6[i] = -9;
     }
-    expected_result0 = expected_result1 = expected_result2 =
-        expected_result3 = expected_result4 = expected_result5 =
-        expected_result6 = 1;
-
-    /*
-    for (i = 1; i <= pe_bound; i++) {
-        expected_result0 = expected_result0 * 2;
-        expected_result1 = expected_result1 * 2;
-        expected_result2 = expected_result2 * 2;
-        expected_result3 = expected_result3 * 2;
-        expected_result4 = expected_result4 * 2;
-        expected_result5 = expected_result5 * 2;
-        expected_result6 = expected_result6 * 2;
-    }
-    */
 
     expected_result0 = 1 << pe_bound;
     expected_result1 = 1 << pe_bound;

--- a/feature_tests/C/test_shmem_reduction.c
+++ b/feature_tests/C/test_shmem_reduction.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_reduction.c
+++ b/feature_tests/C/test_shmem_reduction.c
@@ -515,6 +515,7 @@ main ()
         expected_result3 = expected_result4 = expected_result5 =
         expected_result6 = 1;
 
+    /*
     for (i = 1; i <= pe_bound; i++) {
         expected_result0 = expected_result0 * 2;
         expected_result1 = expected_result1 * 2;
@@ -524,6 +525,15 @@ main ()
         expected_result5 = expected_result5 * 2;
         expected_result6 = expected_result6 * 2;
     }
+    */
+
+    expected_result0 = 1 << pe_bound;
+    expected_result1 = 1 << pe_bound;
+    expected_result2 = 1 << pe_bound;
+    expected_result3 = 1 << pe_bound;
+    expected_result4 = 1 << pe_bound;
+    expected_result5 = 1 << pe_bound;
+    expected_result6 = 1 << pe_bound;
 
     shmem_barrier_all ();
 

--- a/feature_tests/C/test_shmem_reduction.c
+++ b/feature_tests/C/test_shmem_reduction.c
@@ -58,6 +58,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 
 #include <shmem.h>
 
@@ -99,7 +100,7 @@ main ()
     int success0, success1, success2, success3, success4, success5, success6;
 
     int fail_count = 0;
-    int pe_bound;
+    int pe_bound=1;
 
     shmem_init ();
     me = shmem_my_pe ();
@@ -108,9 +109,16 @@ main ()
     success0 = success1 = success2 = success3 = success4 = success5 =
         success6 = 0;
 
-    if(npes > 8)
-        pe_bound = 8;
-    else
+    i = 2;
+
+    while (i < SHRT_MAX) {
+      i = 2 * i;
+      pe_bound++;
+    }
+
+    pe_bound--;
+
+    if (npes < pe_bound)
         pe_bound = npes;
 
     for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i += 1) {
@@ -485,9 +493,9 @@ main ()
     success0 = success1 = success2 = success3 = success4 = success5 =
         success6 = 0;
     for (i = 0; i < N; i += 1) {
-        if (me < 8) {
+        if (me < pe_bound) {
             src0[i] = src1[i] = src2[i] = src3[i] = src4[i] = src5[i] =
-              src6[i] = me + 1;
+              src6[i] = 2;
         }
         else {
             src0[i] = src1[i] = src2[i] = src3[i] = src4[i] = src5[i] =
@@ -508,13 +516,13 @@ main ()
         expected_result6 = 1;
 
     for (i = 1; i <= pe_bound; i++) {
-        expected_result0 = expected_result0 * i;
-        expected_result1 = expected_result1 * i;
-        expected_result2 = expected_result2 * i;
-        expected_result3 = expected_result3 * i;
-        expected_result4 = expected_result4 * i;
-        expected_result5 = expected_result5 * i;
-        expected_result6 = expected_result6 * i;
+        expected_result0 = expected_result0 * 2;
+        expected_result1 = expected_result1 * 2;
+        expected_result2 = expected_result2 * 2;
+        expected_result3 = expected_result3 * 2;
+        expected_result4 = expected_result4 * 2;
+        expected_result5 = expected_result5 * 2;
+        expected_result6 = expected_result6 * 2;
     }
 
     shmem_barrier_all ();

--- a/feature_tests/C/test_shmem_reduction.c
+++ b/feature_tests/C/test_shmem_reduction.c
@@ -100,6 +100,8 @@ main ()
     int checkpoint0, checkpoint1, checkpoint2, checkpoint3, checkpoint4,
         checkpoint5, checkpoint6;
 
+    int fail_count = 0;
+
     shmem_init ();
     me = shmem_my_pe ();
     npes = shmem_n_pes ();
@@ -154,30 +156,35 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_max_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_max_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_max_to_all: Passed\n");
         }
         if (success3 == 1) {
             printf ("Reduction operation shmem_float_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_float_max_to_all: Passed\n");
         }
         if (success4 == 1) {
             printf ("Reduction operation shmem_double_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_double_max_to_all: Passed\n");
@@ -185,6 +192,7 @@ main ()
         if (success5 == 1) {
             printf
                 ("Reduction operation shmem_longdouble_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf
@@ -192,6 +200,7 @@ main ()
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_max_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_max_to_all: Passed\n");
@@ -252,30 +261,35 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_min_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_min_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_min_to_all: Passed\n");
         }
         if (success3 == 1) {
             printf ("Reduction operation shmem_float_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_float_min_to_all: Passed\n");
         }
         if (success4 == 1) {
             printf ("Reduction operation shmem_double_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_double_min_to_all: Passed\n");
@@ -283,6 +297,7 @@ main ()
         if (success5 == 1) {
             printf
                 ("Reduction operation shmem_longdouble_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf
@@ -290,6 +305,7 @@ main ()
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_min_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_min_to_all: Passed\n");
@@ -346,30 +362,35 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_sum_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_sum_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_sum_to_all: Passed\n");
         }
         if (success3 == 1) {
             printf ("Reduction operation shmem_float_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_float_sum_to_all: Passed\n");
         }
         if (success4 == 1) {
             printf ("Reduction operation shmem_double_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_double_sum_to_all: Passed\n");
@@ -377,6 +398,7 @@ main ()
         if (success5 == 1) {
             printf
                 ("Reduction operation shmem_longdouble_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf
@@ -384,6 +406,7 @@ main ()
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_sum_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_sum_to_all: Passed\n");
@@ -425,24 +448,28 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_and_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_and_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_and_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_and_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_and_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_and_to_all: Passed\n");
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_and_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_and_to_all: Passed\n");
@@ -530,6 +557,7 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint0 == 1)
             printf
@@ -539,6 +567,7 @@ main ()
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint1 == 1)
             printf
@@ -549,6 +578,7 @@ main ()
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint2 == 1)
             printf
@@ -559,6 +589,7 @@ main ()
         }
         if (success3 == 1) {
             printf ("Reduction operation shmem_float_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint3 == 1)
             printf
@@ -569,6 +600,7 @@ main ()
         }
         if (success4 == 1) {
             printf ("Reduction operation shmem_double_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint4 == 1)
             printf
@@ -580,6 +612,7 @@ main ()
         if (success5 == 1) {
             printf
                 ("Reduction operation shmem_longdouble_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint5 == 1)
             printf
@@ -591,6 +624,7 @@ main ()
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_prod_to_all: Failed\n");
+            fail_count++;
         }
         else if (checkpoint6 == 1)
             printf
@@ -637,24 +671,28 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_or_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_or_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_or_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_or_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_or_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_or_to_all: Passed\n");
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_or_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_or_to_all: Passed\n");
@@ -698,29 +736,40 @@ main ()
         }
         if (success0 == 1) {
             printf ("Reduction operation shmem_short_xor_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_short_xor_to_all: Passed\n");
         }
         if (success1 == 1) {
             printf ("Reduction operation shmem_int_xor_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_int_xor_to_all: Passed\n");
         }
         if (success2 == 1) {
             printf ("Reduction operation shmem_long_xor_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_long_xor_to_all: Passed\n");
         }
         if (success6 == 1) {
             printf ("Reduction operation shmem_longlong_xor_to_all: Failed\n");
+            fail_count++;
         }
         else {
             printf ("Reduction operation shmem_longlong_xor_to_all: Passed\n");
         }
 
+    }
+
+    if (me == 0) {
+        if (fail_count == 0)
+            printf("All Tests Passed\n");
+        else
+            printf("%d Tests Failed\n", fail_count);
     }
 
     shmem_finalize ();

--- a/feature_tests/C/test_shmem_zero_get.c
+++ b/feature_tests/C/test_shmem_zero_get.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_zero_get.c
+++ b/feature_tests/C/test_shmem_zero_get.c
@@ -68,6 +68,8 @@ main (int argc, char **argv)
     int success1, success2, success3, success4, success5, success6, success7,
         success8;
 
+    int fail_count = 0;
+
     static short src1[N];
     static int src2[N];
     static long src3[N];
@@ -198,38 +200,54 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_get of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_get of zero length: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_getmem of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_getmem of zero length: Failed\n");
-
+                fail_count++;
+            }
         }
+
         shmem_barrier_all ();
 
         /* Testing shmem_get32, shmem_get64, shmem_get128 */
@@ -265,18 +283,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_get32 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get64 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_get128 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128 of zero length: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -312,22 +336,36 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_get32 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get32 of zero length: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_get64 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get64 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_get128 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_get128 of zero length: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
 
         shmem_barrier_all ();
+
+        if (me == 0) {
+              if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
 
         shmem_free (dest1);
         shmem_free (dest2);

--- a/feature_tests/C/test_shmem_zero_put.c
+++ b/feature_tests/C/test_shmem_zero_put.c
@@ -7,6 +7,7 @@
  *   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
  *   (shmem) is released by Open Source Software Solutions, Inc., under an
  *   agreement with Silicon Graphics International Corp. (SGI).
+ * Copyright (c) 2016 Intel Corporation
  *
  * All rights reserved.
  *

--- a/feature_tests/C/test_shmem_zero_put.c
+++ b/feature_tests/C/test_shmem_zero_put.c
@@ -68,6 +68,8 @@ main (int argc, char **argv)
     int success1, success2, success3, success4, success5, success6, success7,
         success8;
 
+    int fail_count = 0;
+
     short src1[N];
     int src2[N];
     long src3[N];
@@ -208,37 +210,52 @@ main (int argc, char **argv)
 
             if (success1 == 0)
                 printf ("Test shmem_short_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_short_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success2 == 0)
                 printf ("Test shmem_int_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_int_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success3 == 0)
                 printf ("Test shmem_long_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_long_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success4 == 0)
                 printf ("Test shmem_longdouble_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longdouble_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success5 == 0)
                 printf ("Test shmem_longlong_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_longlong_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success6 == 0)
                 printf ("Test shmem_double_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_double_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success7 == 0)
                 printf ("Test shmem_float_put of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_float_put of zero length: Failed\n");
+                fail_count++;
+            }
             if (success8 == 0)
                 printf ("Test shmem_putmem of zero length: Passed\n");
-            else
+            else {
                 printf ("Test shmem_putmem of zero length: Failed\n");
-
+                fail_count++;
+            }
         }
         shmem_barrier_all ();
 
@@ -275,18 +292,24 @@ main (int argc, char **argv)
                 }
                 if (success2 == 0)
                     printf ("Test shmem_put32 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put64 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success4 == 0)
                     printf ("Test shmem_put128 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128 of zero length: Failed\n");
+                    fail_count++;
+                }
             }
         }
         else if (sizeof (int) == 8) {
@@ -322,22 +345,36 @@ main (int argc, char **argv)
                 }
                 if (success1 == 0)
                     printf ("Test shmem_put32 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put32 of zero length: Failed\n");
+                    fail_count++;
+                }
+
                 if (success2 == 0)
                     printf ("Test shmem_put64 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put64 of zero length: Failed\n");
+                    fail_count++;
+                }
 
                 if (success3 == 0)
                     printf ("Test shmem_put128 of zero length: Passed\n");
-                else
+                else {
                     printf ("Test shmem_put128 of zero length: Failed\n");
+                    fail_count++;
+                }
             }
         }
 
 
         shmem_barrier_all ();
+
+        if (me == 0) {
+            if (fail_count == 0)
+                printf("All Tests Passed\n");
+            else
+                printf("%d Tests Failed\n", fail_count);
+        }
 
         shmem_free (dest1);
         shmem_free (dest2);


### PR DESCRIPTION
Update C tests to use the UH testrunner harness:
- The C feature tests have been updated to use the testrunner.pl test harness.  This required updating the Makefile and adding Makefile.opts and test_parameters.conf files into the feature_tests/C directory.
- C feature tests were updated to produce the Pass/Fail output expected by the testrunner harness.
- Several bugs in the C tests were found and fixed along the way.
- The testrunner harness was extended to support using at the exit code to determine pass/fail status.  This is needed to support testing shmem_global_exit and should be generally useful.
