### PR TITLE
Helpers to run the tests though the Open MPI testing environment

### DIFF
--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -68,8 +68,14 @@ our $TEST_NOTFOUND = "NotFound";
 our $TEST_UNDEF = "Undef";
 our $TEST_TIMEOUT = "Timeout";
 our $RUN_CMD="oshrun";
+our $RUN_OPTIONS="";
 our $SHELL_OPT="2>&1";
 our $TEST_CONFIG_FILE="test_parameters.conf";
+
+# Let the user override the RUN_OPTIONS, if desired (e.g., for setting
+# OpenSHMEM-specific "oshrun" CLI options).
+$RUN_OPTIONS = $ENV{RUN_OPTIONS}
+    if (exists($ENV{RUN_OPTIONS}));
 
 our $ht_stats = {
   'total'    => '0',
@@ -127,7 +133,7 @@ sub execute_test($){
   my $log_filename = "$test_config->{'executable'}" . ".log";
   my $log_fh;
 
-  @output = `$RUN_CMD -np $test_config->{'npes'} ./$test_config->{'executable'} 2>&1`;
+  @output = `$RUN_CMD $RUN_OPTIONS -np $test_config->{'npes'} ./$test_config->{'executable'} 2>&1`;
 
   open $log_fh, '>', $log_filename or die "Error opening log file '$log_filename'";
   print $log_fh "@output";

--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -55,9 +55,6 @@
 # TODO: logging of individual tests ? to find out more about a failed test
 
 use strict;
-use Env;
-use Env qw(PATH HOME TERM);
-use Env qw($SHELL @LD_LIBRARY_PATH);
 use Time::HiRes qw( usleep ualarm gettimeofday tv_interval nanosleep
                       clock stat );
 use Data::Dumper;

--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -94,7 +94,28 @@ my $ht_configuration;
 
 $ht_configuration = read_test_config $TEST_CONFIG_FILE;
 
-test_runner $ht_configuration;
+# If arguments were specified on the CLI, use those as a filter for
+# which tests to run.  Abort if a test was specified for which we do
+# not have a configuration.
+if (defined(@ARGV)) {
+    my $tests_to_run;
+    foreach my $arg (@ARGV) {
+        my $found = 0;
+        foreach my $key (sort(keys(%{$ht_configuration}))) {
+            if ($ht_configuration->{$key}->{executable} eq $arg) {
+                $found = 1;
+                $tests_to_run->{$key} = $ht_configuration->{$key};
+                last;
+            }
+        }
+
+        die "Test not found: $arg"
+            if (!$found);
+    }
+    test_runner $tests_to_run;
+} else {
+    test_runner $ht_configuration;
+}
 
 exit(0);
 


### PR DESCRIPTION
3 minor improvements to make it easier to run these tests through the Open MPI testing environment (i.e., MTT).  I did each improvement as a separate commit so that you can see each as a small, self-contained, easily-reviewable entity:

1. Remove superfluous use of the perl Env module
1. Allow the user to specify run-time options to $RUN_CMD
    * This will allow me to run these tests through Open MPI's MTT, and specify Open MPI-specific CLI options to `oshrun` (e.g., `--map-by node`, to force the OSHMEM tests to run across multiple nodes).
1. Allow the user to specify exactly which tests to run
    * MTT likes to run one test at a time so that it can report individual results, and control individual timeouts.  However, testrunner.pl has a bunch of infrastructure -- e.g., for reading test_parameters.conf.  So it would be great if we could have MTT run `testrunner.pl` for each test, and therefore a) MTT gets to run tests individually, and b) we can still use all the infrastructure in `testrunner.pl`.
