### PR TITLE
Revert "Kill timed out launcher process and its children"

### DIFF
--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -205,8 +205,7 @@ sub run_test($$) {
 
 	$child_pid = fork();
 	if($child_pid == 0){
-		setpgrp(0, 0);
-		my $rc = execute_test $test_config;
+	  my $rc = execute_test $test_config;
 		if($rc eq $TEST_OK){
 			kill 1, getppid(); # signal the parent that test passed.
 		}else{
@@ -227,8 +226,7 @@ sub run_test($$) {
 			if($test_config->{'timeout'} != 0 && $elapsed >= $test_config->{'timeout'}){
 
 				# terminate the child process and check the results
-				kill 9, -$child_pid;
-
+				kill 9, $child_pid;
 				if($test_result eq $TEST_UNDEF){
 				  # We may be expecting a timeout to occur
 					if($test_config->{'expect'} eq $TEST_TIMEOUT){


### PR DESCRIPTION
Reverts openshmem-org/tests-uh#18

Sorry about that - I should have tested this on Linux more thoroughly.  I'm convinced there's a Perl bug when using `setpgrp` and then a subsequent "backtick" call on Linux.  I see it in Perl 5.18 on Ubuntu 14.04 and Perl 5.22 on Ubuntu 16.04.  I've tried several alternate routes - It seems like system() works with setpgrp, but that complicates how we parse the stdout further along.  For now, I think we should revert this change until a better solution presents itself.  

Side note: I've tested the simple approach of replacing `kill 9, $child_pid` with `kill 9, $child_pid, $child_pid+1` many times on a few different OS's without a single problem, so there's always that option.  The +1 process _seems_ to always be the launcher (oshrun/mpirun).  It just doesn't seem like the most safe thing to assume...