### PR TITLE
Update test runner to kill launched tests directly on timeout

### DIFF
--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -157,7 +157,7 @@ sub execute_test($){
   my $test_pid = open TEST_OUT, "-|", "$RUN_CMD $RUN_OPTIONS -np $test_config->{'npes'} ./$test_config->{'executable'} 2>&1";
 
   $SIG{'INT'} = sub {
-      kill 9, $test_pid;
+      kill 'KILL', $test_pid;
       exit;
   };
 
@@ -219,9 +219,9 @@ sub run_test($$) {
 	if($child_pid == 0){
 		my $rc = execute_test $test_config;
 		if($rc eq $TEST_OK){
-			kill 1, getppid(); # signal the parent that test passed.
+			kill 'HUP', getppid(); # signal the parent that test passed.
 		}else{
-			kill 2, getppid(); # signal the parent that test failed.
+			kill 'INT', getppid(); # signal the parent that test failed.
 		}
 		exit 0; # kill child
 	}else{
@@ -238,7 +238,8 @@ sub run_test($$) {
 			if($test_config->{'timeout'} != 0 && $elapsed >= $test_config->{'timeout'}){
 
 				# terminate the child process and check the results
-				kill 2, $child_pid;
+				kill 'INT', $child_pid;
+
 				if($test_result eq $TEST_UNDEF){
 				  # We may be expecting a timeout to occur
 					if($test_config->{'expect'} eq $TEST_TIMEOUT){

--- a/common/testrunner.pl
+++ b/common/testrunner.pl
@@ -154,7 +154,19 @@ sub execute_test($){
   my $log_filename = "$test_config->{'executable'}" . ".log";
   my $log_fh;
 
-  @output = `$RUN_CMD $RUN_OPTIONS -np $test_config->{'npes'} ./$test_config->{'executable'} 2>&1`;
+  my $test_pid = open TEST_OUT, "-|", "$RUN_CMD $RUN_OPTIONS -np $test_config->{'npes'} ./$test_config->{'executable'} 2>&1";
+
+  $SIG{'INT'} = sub {
+      kill 9, $test_pid;
+      exit;
+  };
+
+  if ($test_pid) {
+    @output = <TEST_OUT>;
+    close TEST_OUT;
+  } else {
+    @output = $!;
+  }
 
   open $log_fh, '>', $log_filename or die "Error opening log file '$log_filename'";
   print $log_fh "@output";
@@ -205,7 +217,6 @@ sub run_test($$) {
 
 	$child_pid = fork();
 	if($child_pid == 0){
-		setpgrp(0, 0);
 		my $rc = execute_test $test_config;
 		if($rc eq $TEST_OK){
 			kill 1, getppid(); # signal the parent that test passed.
@@ -227,7 +238,7 @@ sub run_test($$) {
 			if($test_config->{'timeout'} != 0 && $elapsed >= $test_config->{'timeout'}){
 
 				# terminate the child process and check the results
-				kill 9, -$child_pid;
+				kill 2, $child_pid;
 
 				if($test_result eq $TEST_UNDEF){
 				  # We may be expecting a timeout to occur


### PR DESCRIPTION
Jim found a nice way to get what we want.  I've tested this successfully on Linux and OSX:

Signal routing seems to be unreliable.  Instead of relying on the
test runner to forward SIGKILL, sent SIGNIT so it can kill test
processes and exit.