### PR TITLE
more fixes for Cray and Sandia OpenSHMEM

### DIFF
--- a/error_tests/Fortran/transfer/test_shmem_put_05_char.f90
+++ b/error_tests/Fortran/transfer/test_shmem_put_05_char.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2017
+!    Los Alamos National Security, LLC. All rights reserved.
 !
 ! All rights reserved.
 !
@@ -89,7 +91,7 @@ program test_shmem_put
 
     if(me .eq. 0) then
       do i = 1, N, 1
-        if(dest(i) .ne. CHAR(40 + i)) then
+        if(dest(i) .eq. CHAR(40 + i)) then
           success1 = .FALSE.
         end if
       end do

--- a/error_tests/Fortran/transfer/test_shmem_put_05_double.f90
+++ b/error_tests/Fortran/transfer/test_shmem_put_05_double.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2017
+!   Los Alamos National Security, LLC. All rights reserved.
 !
 ! All rights reserved.
 !
@@ -89,7 +91,7 @@ program test_shmem_put
 
     if(me .eq. 0) then
       do i = 1, N, 1
-        if(dest(i) .ne. 54321.67 + DBLE(i)) then
+        if(dest(i) .eq. 54321.67 + DBLE(i)) then
           success1 = .FALSE.
         end if
       end do

--- a/error_tests/Fortran/transfer/test_shmem_put_05_int4.f90
+++ b/error_tests/Fortran/transfer/test_shmem_put_05_int4.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2017
+!   Los Alamos National Security, LLC. All rights reserved.
 !
 ! All rights reserved.
 !
@@ -89,7 +91,7 @@ program test_shmem_put
 
     if(me .eq. 0) then
       do i = 1, N, 1
-        if(dest(i) .ne. 54321 + i) then
+        if(dest(i) .eq. 54321 + i) then
           success1 = .FALSE.
         end if
       end do

--- a/error_tests/Fortran/transfer/test_shmem_put_05_logical.f90
+++ b/error_tests/Fortran/transfer/test_shmem_put_05_logical.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2017
+!   Los Alamos National Security, LLC. All rights reserved.
 !
 ! All rights reserved.
 !
@@ -89,7 +91,7 @@ program test_shmem_put
 
     if(me .eq. 0) then
       do i = 1, N, 1
-        if(dest(i) .neqv. .TRUE.) then
+        if(dest(i) .eqv. .TRUE.) then
           success1 = .FALSE.
         end if
       end do

--- a/error_tests/Fortran/transfer/test_shmem_put_05_real4.f90
+++ b/error_tests/Fortran/transfer/test_shmem_put_05_real4.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2017
+!    Los Alamos National Security, LLC. All rights reserved.
 !
 ! All rights reserved.
 !
@@ -89,7 +91,7 @@ program test_shmem_put
 
     if(me .eq. 0) then
       do i = 1, N, 1
-        if(dest(i) .ne. REAL(54321 + i, KIND=4)) then
+        if(dest(i) .eq. REAL(54321 + i, KIND=4)) then
           success1 = .FALSE.
         end if
       end do


### PR DESCRIPTION
Turns out the logic was wrong in the tests in this commit.

The tests were only working because the default for some
OpenSHMEM's is to do strict error checking, or that the
underlying transport layer melts down when the target of
a put is not in the symmetric heap or data segment.

Fix this so now the tests fail when compiled against
Cray and OpenSHMEM.

Oh, and by the way, none of the fortran tests in this repo
can be compiled with the Cray compile wrappers/cray-shmem
module unless they are modified.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>