### PR TITLE
fortran/broadcast: fix nelems arg in broadcast

### DIFF
--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_char.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_char.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -79,7 +81,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast4(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast4(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_double.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_double.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -77,7 +79,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast8(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast8(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_int4.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_int4.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -77,7 +79,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast4(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast4(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_int8.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_int8.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -77,7 +79,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast8(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast8(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_logical.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_logical.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -79,7 +81,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast4(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast4(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_real4.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_real4.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -77,7 +79,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast4(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast4(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 

--- a/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_real8.f90
+++ b/feature_tests/Fortran/broadcast/test_shmem_broadcast_04_real8.f90
@@ -7,6 +7,8 @@
 !   by Silicon Graphics International Corp. (SGI) The OpenSHMEM API
 !   (shmem) is released by Open Source Software Solutions, Inc., under an
 !   agreement with Silicon Graphics International Corp. (SGI).
+! Copyright (c) 2018 Los Alamos National Security, LLC.
+!   All rights reserved.
 !
 ! All rights reserved.
 !
@@ -77,7 +79,7 @@ program test_shmem_broadcast
 
     call shmem_barrier_all()
 
-    call shmem_broadcast8(dest, src, 0, 0, 0, 0, npes, pSync)
+    call shmem_broadcast8(dest, src, nelems, 0, 0, 0, npes, pSync)
 
     call shmem_barrier_all()
 


### PR DESCRIPTION
Not sure how these were ever working.  Replace
zero with nelems in third argument to shmem_broadcast.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>